### PR TITLE
Menu Drawer and Theme 

### DIFF
--- a/parkcore_app/lib/add_parking.dart
+++ b/parkcore_app/lib/add_parking.dart
@@ -1,0 +1,59 @@
+import 'package:flutter/material.dart';
+
+class AddParking extends StatefulWidget {
+  AddParking({Key key, this.title}) : super(key: key);
+  // This widget is the "add parking" page of the app. It is stateful: it has a
+  // State object (defined below) that contains fields that affect how it looks.
+  // This class is the configuration for the state. It holds the values (title)
+  // provided by the parent (App widget) and used by the build method of the
+  // State. Fields in a Widget subclass are always marked "final".
+
+  final String title;
+
+  @override
+  _MyAddParkingState createState() => _MyAddParkingState();
+}
+
+class _MyAddParkingState extends State<AddParking> {
+
+  @override
+  Widget build(BuildContext context) {
+    // build(): rerun every time setState is called (e.g. for stateful methods)
+    // Rebuild anything that needs updating instead of having to individually
+    // change instances of widgets.
+    return Scaffold(
+      appBar: AppBar(
+        leading: IconButton(
+          icon: new Icon(Icons.close),
+          onPressed: () => Navigator.pushNamed(context, '/home'),
+        ),
+        title: Text(widget.title),
+        centerTitle: true,
+        backgroundColor: Colors.green[900],
+      ),
+      body: Center(
+        child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: <Widget>[
+              Text(
+                'Post Your Parking Space',
+                style: TextStyle(
+                  fontSize: 20,
+                  fontWeight: FontWeight.bold,
+                  letterSpacing: 2.0,
+                  color: Colors.grey[600],
+                ),
+              ),
+            ]
+        ),
+      ),
+//      floatingActionButton: FloatingActionButton(
+//        onPressed: () {
+//          Navigator.pushNamed(context, '/home');
+//        },
+//        child: Icon(Icons.home),
+//        backgroundColor: Colors.green[700],
+//      ),
+    );
+  }
+}

--- a/parkcore_app/lib/add_parking.dart
+++ b/parkcore_app/lib/add_parking.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:parkcore_app/menu_drawer.dart';
 
 class AddParking extends StatefulWidget {
   AddParking({Key key, this.title}) : super(key: key);
@@ -23,14 +24,17 @@ class _MyAddParkingState extends State<AddParking> {
     // change instances of widgets.
     return Scaffold(
       appBar: AppBar(
-        leading: IconButton(
-          icon: new Icon(Icons.close),
-          onPressed: () => Navigator.pushNamed(context, '/home'),
-        ),
         title: Text(widget.title),
         centerTitle: true,
         backgroundColor: Colors.green[900],
+        actions: <Widget>[
+          new IconButton(
+            icon: new Icon(Icons.close),
+            onPressed: () => Navigator.pushNamed(context, '/home'),
+          ),
+        ],
       ),
+      drawer: MenuDrawer(),
       body: Center(
         child: Column(
             mainAxisAlignment: MainAxisAlignment.center,

--- a/parkcore_app/lib/add_parking.dart
+++ b/parkcore_app/lib/add_parking.dart
@@ -26,7 +26,7 @@ class _MyAddParkingState extends State<AddParking> {
       appBar: AppBar(
         title: Text(widget.title),
         centerTitle: true,
-        backgroundColor: Colors.green[900],
+        backgroundColor: Theme.of(context).backgroundColor,
       ),
       drawer: MenuDrawer(),
       body: Center(
@@ -35,23 +35,11 @@ class _MyAddParkingState extends State<AddParking> {
             children: <Widget>[
               Text(
                 'Post Your Parking Space',
-                style: TextStyle(
-                  fontSize: 20,
-                  fontWeight: FontWeight.bold,
-                  letterSpacing: 2.0,
-                  color: Colors.grey[600],
-                ),
+                style: Theme.of(context).textTheme.headline3,
               ),
             ]
         ),
       ),
-//      floatingActionButton: FloatingActionButton(
-//        onPressed: () {
-//          Navigator.pushNamed(context, '/home');
-//        },
-//        child: Icon(Icons.home),
-//        backgroundColor: Colors.green[700],
-//      ),
     );
   }
 }

--- a/parkcore_app/lib/add_parking.dart
+++ b/parkcore_app/lib/add_parking.dart
@@ -27,12 +27,6 @@ class _MyAddParkingState extends State<AddParking> {
         title: Text(widget.title),
         centerTitle: true,
         backgroundColor: Colors.green[900],
-        actions: <Widget>[
-          new IconButton(
-            icon: new Icon(Icons.close),
-            onPressed: () => Navigator.pushNamed(context, '/home'),
-          ),
-        ],
       ),
       drawer: MenuDrawer(),
       body: Center(

--- a/parkcore_app/lib/find_parking.dart
+++ b/parkcore_app/lib/find_parking.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:parkcore_app/menu_drawer.dart';
 
 class FindParking extends StatefulWidget {
   FindParking({Key key, this.title}) : super(key: key);
@@ -23,14 +24,17 @@ class _MyFindParkingState extends State<FindParking> {
     // change instances of widgets.
     return Scaffold(
       appBar: AppBar(
-        leading: IconButton(
-          icon: new Icon(Icons.close),
-          onPressed: () => Navigator.pushNamed(context, '/home'),
-        ),
         title: Text(widget.title),
         centerTitle: true,
         backgroundColor: Colors.green[900],
+        actions: <Widget>[
+          new IconButton(
+            icon: new Icon(Icons.close),
+            onPressed: () => Navigator.pushNamed(context, '/home'),
+          ),
+        ],
       ),
+      drawer: MenuDrawer(),
       body: Center(
         child: Column(
             mainAxisAlignment: MainAxisAlignment.center,

--- a/parkcore_app/lib/find_parking.dart
+++ b/parkcore_app/lib/find_parking.dart
@@ -27,12 +27,6 @@ class _MyFindParkingState extends State<FindParking> {
         title: Text(widget.title),
         centerTitle: true,
         backgroundColor: Colors.green[900],
-        actions: <Widget>[
-          new IconButton(
-            icon: new Icon(Icons.close),
-            onPressed: () => Navigator.pushNamed(context, '/home'),
-          ),
-        ],
       ),
       drawer: MenuDrawer(),
       body: Center(

--- a/parkcore_app/lib/find_parking.dart
+++ b/parkcore_app/lib/find_parking.dart
@@ -1,0 +1,59 @@
+import 'package:flutter/material.dart';
+
+class FindParking extends StatefulWidget {
+  FindParking({Key key, this.title}) : super(key: key);
+  // This widget is the "find parking" page of the app. It is stateful: it has a
+  // State object (defined below) that contains fields that affect how it looks.
+  // This class is the configuration for the state. It holds the values (title)
+  // provided by the parent (App widget) and used by the build method of the
+  // State. Fields in a Widget subclass are always marked "final".
+
+  final String title;
+
+  @override
+  _MyFindParkingState createState() => _MyFindParkingState();
+}
+
+class _MyFindParkingState extends State<FindParking> {
+
+  @override
+  Widget build(BuildContext context) {
+    // build(): rerun every time setState is called (e.g. for stateful methods)
+    // Rebuild anything that needs updating instead of having to individually
+    // change instances of widgets.
+    return Scaffold(
+      appBar: AppBar(
+        leading: IconButton(
+          icon: new Icon(Icons.close),
+          onPressed: () => Navigator.pushNamed(context, '/home'),
+        ),
+        title: Text(widget.title),
+        centerTitle: true,
+        backgroundColor: Colors.green[900],
+      ),
+      body: Center(
+        child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: <Widget>[
+              Text(
+                'Find Parking',
+                style: TextStyle(
+                  fontSize: 20,
+                  fontWeight: FontWeight.bold,
+                  letterSpacing: 2.0,
+                  color: Colors.grey[600],
+                ),
+              ),
+            ]
+        ),
+      ),
+//      floatingActionButton: FloatingActionButton(
+//        onPressed: () {
+//          Navigator.pushNamed(context, '/home');
+//        },
+//        child: Icon(Icons.home),
+//        backgroundColor: Colors.green[700],
+//      ),
+    );
+  }
+}

--- a/parkcore_app/lib/find_parking.dart
+++ b/parkcore_app/lib/find_parking.dart
@@ -26,7 +26,7 @@ class _MyFindParkingState extends State<FindParking> {
       appBar: AppBar(
         title: Text(widget.title),
         centerTitle: true,
-        backgroundColor: Colors.green[900],
+        backgroundColor: Theme.of(context).backgroundColor,
       ),
       drawer: MenuDrawer(),
       body: Center(
@@ -35,23 +35,11 @@ class _MyFindParkingState extends State<FindParking> {
             children: <Widget>[
               Text(
                 'Find Parking',
-                style: TextStyle(
-                  fontSize: 20,
-                  fontWeight: FontWeight.bold,
-                  letterSpacing: 2.0,
-                  color: Colors.grey[600],
-                ),
+                style: Theme.of(context).textTheme.headline3,
               ),
             ]
         ),
       ),
-//      floatingActionButton: FloatingActionButton(
-//        onPressed: () {
-//          Navigator.pushNamed(context, '/home');
-//        },
-//        child: Icon(Icons.home),
-//        backgroundColor: Colors.green[700],
-//      ),
     );
   }
 }

--- a/parkcore_app/lib/home.dart
+++ b/parkcore_app/lib/home.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:parkcore_app/style.dart';
 
 
 class MyHomePage extends StatefulWidget {
@@ -46,6 +47,41 @@ class _MyHomePageState extends State<MyHomePage> {
           ),
         ],
       ),
+      drawer: Drawer(
+        child: ListView(
+          padding: EdgeInsets.zero,
+          children: <Widget>[
+            DrawerHeader(
+              child: Text('Drawer Header'),
+              decoration: BoxDecoration(
+                color: Theme.of(context).primaryColor,
+              ),
+            ),
+            ListTile(
+              title: Text('Add Parking'),
+              trailing: Icon(Icons.arrow_forward),
+              onTap: () {
+                // Update the state of the app.
+                // ...
+                // Then close the drawer.
+                Navigator.pushNamed(context, '/add_parking');
+                //Navigator.pop(context);
+              },
+            ),
+            ListTile(
+              title: Text('Find Parking'),
+              trailing: Icon(Icons.arrow_forward),
+              onTap: () {
+                // Update the state of the app.
+                // ...
+                // Then close the drawer.
+                Navigator.pushNamed(context, '/find_parking');
+               // Navigator.pop(context);
+              },
+            ),
+          ],
+        ),
+      ),
       body: Center(
         child: Column(
             mainAxisAlignment: MainAxisAlignment.center,
@@ -55,7 +91,9 @@ class _MyHomePageState extends State<MyHomePage> {
               ),
               Text(
                 '$_counter',
-                style: Theme.of(context).textTheme.display1,
+                style: TextStyle(
+                  color: Colors.green[900],
+                ),
               ),
             ]
         ),

--- a/parkcore_app/lib/home.dart
+++ b/parkcore_app/lib/home.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:parkcore_app/style.dart';
+import 'package:parkcore_app/menu_drawer.dart';
 
 
 class MyHomePage extends StatefulWidget {
@@ -47,41 +47,7 @@ class _MyHomePageState extends State<MyHomePage> {
           ),
         ],
       ),
-      drawer: Drawer(
-        child: ListView(
-          padding: EdgeInsets.zero,
-          children: <Widget>[
-            DrawerHeader(
-              child: Text('Drawer Header'),
-              decoration: BoxDecoration(
-                color: Theme.of(context).primaryColor,
-              ),
-            ),
-            ListTile(
-              title: Text('Add Parking'),
-              trailing: Icon(Icons.arrow_forward),
-              onTap: () {
-                // Update the state of the app.
-                // ...
-                // Then close the drawer.
-                Navigator.pushNamed(context, '/add_parking');
-                //Navigator.pop(context);
-              },
-            ),
-            ListTile(
-              title: Text('Find Parking'),
-              trailing: Icon(Icons.arrow_forward),
-              onTap: () {
-                // Update the state of the app.
-                // ...
-                // Then close the drawer.
-                Navigator.pushNamed(context, '/find_parking');
-               // Navigator.pop(context);
-              },
-            ),
-          ],
-        ),
-      ),
+      drawer: MenuDrawer(),
       body: Center(
         child: Column(
             mainAxisAlignment: MainAxisAlignment.center,

--- a/parkcore_app/lib/home.dart
+++ b/parkcore_app/lib/home.dart
@@ -39,7 +39,7 @@ class _MyHomePageState extends State<MyHomePage> {
       appBar: AppBar(
         title: Text(widget.title),
         centerTitle: true,
-        backgroundColor: Colors.green[900],
+        backgroundColor: Theme.of(context).backgroundColor,
         actions: <Widget>[
           new IconButton(
             icon: new Icon(Icons.close),
@@ -52,14 +52,10 @@ class _MyHomePageState extends State<MyHomePage> {
         child: Column(
             mainAxisAlignment: MainAxisAlignment.center,
             children: <Widget>[
-              Text(
-                'You have pushed the button this many times:',
-              ),
+              Text('You have pushed the button this many times:'),
               Text(
                 '$_counter',
-                style: TextStyle(
-                  color: Colors.green[900],
-                ),
+                style: Theme.of(context).textTheme.headline5,
               ),
             ]
         ),
@@ -68,7 +64,7 @@ class _MyHomePageState extends State<MyHomePage> {
         onPressed: _incrementCounter,
         tooltip: 'Increment',
         child: Icon(Icons.add),
-        backgroundColor: Colors.green[700],
+        backgroundColor: Theme.of(context).backgroundColor,
       ),
     );
   }

--- a/parkcore_app/lib/menu_drawer.dart
+++ b/parkcore_app/lib/menu_drawer.dart
@@ -8,42 +8,51 @@ class MenuDrawer extends StatelessWidget {
         padding: EdgeInsets.zero,
         children: <Widget>[
           DrawerHeader(
-            child: Text('ParkCore'),
+            child: Text(
+                'ParkCore',
+              style: Theme.of(context).textTheme.headline2,
+            ),
             decoration: BoxDecoration(
               color: Theme.of(context).primaryColor,
             ),
           ),
           ListTile(
-            title: Text('Home'),
+            title: Text(
+              'Home',
+              style: Theme.of(context).textTheme.headline5,
+            ),
             trailing: Icon(Icons.arrow_forward),
             onTap: () {
               // Update the state of the app.
               // ...
               // Then close the drawer.
               Navigator.pushNamed(context, '/home');
-              //Navigator.pop(context);
             },
           ),
           ListTile(
-            title: Text('Add Parking'),
+            title: Text(
+              'Add Parking',
+              style: Theme.of(context).textTheme.headline5,
+            ),
             trailing: Icon(Icons.arrow_forward),
             onTap: () {
               // Update the state of the app.
               // ...
               // Then close the drawer.
               Navigator.pushNamed(context, '/add_parking');
-              //Navigator.pop(context);
             },
           ),
           ListTile(
-            title: Text('Find Parking'),
+            title: Text(
+              'Find Parking',
+              style: Theme.of(context).textTheme.headline5,
+            ),
             trailing: Icon(Icons.arrow_forward),
             onTap: () {
               // Update the state of the app.
               // ...
               // Then close the drawer.
               Navigator.pushNamed(context, '/find_parking');
-              // Navigator.pop(context);
             },
           ),
         ],

--- a/parkcore_app/lib/menu_drawer.dart
+++ b/parkcore_app/lib/menu_drawer.dart
@@ -1,0 +1,53 @@
+import 'package:flutter/material.dart';
+
+class MenuDrawer extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Drawer(
+      child: ListView(
+        padding: EdgeInsets.zero,
+        children: <Widget>[
+          DrawerHeader(
+            child: Text('Drawer Header'),
+            decoration: BoxDecoration(
+              color: Theme.of(context).primaryColor,
+            ),
+          ),
+          ListTile(
+            title: Text('Home'),
+            trailing: Icon(Icons.arrow_forward),
+            onTap: () {
+              // Update the state of the app.
+              // ...
+              // Then close the drawer.
+              Navigator.pushNamed(context, '/home');
+              //Navigator.pop(context);
+            },
+          ),
+          ListTile(
+            title: Text('Add Parking'),
+            trailing: Icon(Icons.arrow_forward),
+            onTap: () {
+              // Update the state of the app.
+              // ...
+              // Then close the drawer.
+              Navigator.pushNamed(context, '/add_parking');
+              //Navigator.pop(context);
+            },
+          ),
+          ListTile(
+            title: Text('Find Parking'),
+            trailing: Icon(Icons.arrow_forward),
+            onTap: () {
+              // Update the state of the app.
+              // ...
+              // Then close the drawer.
+              Navigator.pushNamed(context, '/find_parking');
+              // Navigator.pop(context);
+            },
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/parkcore_app/lib/menu_drawer.dart
+++ b/parkcore_app/lib/menu_drawer.dart
@@ -16,47 +16,42 @@ class MenuDrawer extends StatelessWidget {
               color: Theme.of(context).primaryColor,
             ),
           ),
-          ListTile(
-            title: Text(
-              'Home',
-              style: Theme.of(context).textTheme.headline5,
-            ),
-            trailing: Icon(Icons.arrow_forward),
-            onTap: () {
-              // Update the state of the app.
-              // ...
-              // Then close the drawer.
-              Navigator.pushNamed(context, '/home');
-            },
+          _createMenuItem(
+            context: context, icon: Icons.home, text: 'Home', route: '/home',
           ),
-          ListTile(
-            title: Text(
-              'Add Parking',
-              style: Theme.of(context).textTheme.headline5,
-            ),
-            trailing: Icon(Icons.arrow_forward),
-            onTap: () {
-              // Update the state of the app.
-              // ...
-              // Then close the drawer.
-              Navigator.pushNamed(context, '/add_parking');
-            },
+          _createMenuItem(
+            context: context, icon: Icons.directions_car,
+            text: 'Post a Parking Space', route: '/add_parking',
           ),
-          ListTile(
-            title: Text(
-              'Find Parking',
-              style: Theme.of(context).textTheme.headline5,
-            ),
-            trailing: Icon(Icons.arrow_forward),
-            onTap: () {
-              // Update the state of the app.
-              // ...
-              // Then close the drawer.
-              Navigator.pushNamed(context, '/find_parking');
-            },
+          _createMenuItem(
+            context: context, icon: Icons.add_location,
+            text: 'Find Parking', route: '/find_parking',
           ),
         ],
       ),
     );
   }
+}
+
+Widget _createMenuItem(
+    {BuildContext context, IconData icon, String text, String route}) {
+  return ListTile(
+    title: Row(
+      children: <Widget>[
+        Icon(icon),
+        Padding(
+          padding: EdgeInsets.only(left: 8.0),
+          child: Text(
+            text,
+            style: Theme.of(context).textTheme.headline5,
+          ),
+        )
+      ],
+    ),
+    trailing: Icon(Icons.arrow_forward),
+    onTap: () {
+      // Update the state of the app, then close the drawer.
+      Navigator.pushNamed(context, route);
+    },
+  );
 }

--- a/parkcore_app/lib/menu_drawer.dart
+++ b/parkcore_app/lib/menu_drawer.dart
@@ -8,7 +8,7 @@ class MenuDrawer extends StatelessWidget {
         padding: EdgeInsets.zero,
         children: <Widget>[
           DrawerHeader(
-            child: Text('Drawer Header'),
+            child: Text('ParkCore'),
             decoration: BoxDecoration(
               color: Theme.of(context).primaryColor,
             ),

--- a/parkcore_app/lib/onboard.dart
+++ b/parkcore_app/lib/onboard.dart
@@ -29,7 +29,7 @@ class _MyOnBoardState extends State<OnBoard> {
         ),
         title: Text(widget.title),
         centerTitle: true,
-        backgroundColor: Colors.green[900],
+        backgroundColor: Theme.of(context).backgroundColor,
       ),
       body: Center(
         child: Column(
@@ -37,12 +37,7 @@ class _MyOnBoardState extends State<OnBoard> {
             children: <Widget>[
               Text(
                 'Welcome to ParkCore!',
-                style: TextStyle(
-                  fontSize: 20,
-                  fontWeight: FontWeight.bold,
-                  letterSpacing: 2.0,
-                  color: Colors.grey[600],
-                ),
+                style: Theme.of(context).textTheme.headline3,
               ),
             ]
         ),
@@ -52,7 +47,7 @@ class _MyOnBoardState extends State<OnBoard> {
           Navigator.pushNamed(context, '/home');
         },
         child: Icon(Icons.home),
-        backgroundColor: Colors.green[700],
+        backgroundColor: Theme.of(context).backgroundColor,
       ),
     );
   }

--- a/parkcore_app/lib/routes.dart
+++ b/parkcore_app/lib/routes.dart
@@ -1,8 +1,13 @@
 import 'package:flutter/widgets.dart';
 import 'package:parkcore_app/home.dart';
 import 'package:parkcore_app/onboard.dart';
+import 'package:parkcore_app/add_parking.dart';
+import 'package:parkcore_app/find_parking.dart';
+
 
 final Map<String, WidgetBuilder> routes = <String, WidgetBuilder>{
   '/': (context) => OnBoard(title: 'Welcome'),
   '/home': (context) => MyHomePage(title: 'ParkCore'),
+  '/add_parking': (context) => AddParking(title: 'Add Parking'),
+  '/find_parking': (context) => FindParking(title: 'Find Parking'),
 };

--- a/parkcore_app/lib/style.dart
+++ b/parkcore_app/lib/style.dart
@@ -3,5 +3,24 @@ import 'package:flutter/material.dart';
 ThemeData appTheme() {
   return ThemeData(
     primarySwatch: Colors.green,
+    backgroundColor: Colors.green[900],
+    textTheme: TextTheme(
+      headline2: TextStyle(
+        fontSize: 36.0,
+        fontWeight: FontWeight.bold,
+        fontStyle: FontStyle.italic,
+        color: Colors.white70,
+      ),
+      headline3: TextStyle(
+        fontSize: 24,
+        fontWeight: FontWeight.bold,
+        letterSpacing: 2.0,
+        color: Colors.grey[600],
+      ),
+      headline5: TextStyle(
+        fontSize: 20.0,
+        fontFamily: 'Georgia',
+      ),
+    ),
   );
 }


### PR DESCRIPTION
The main purpose of this commit is to start building a menu (as a Drawer widget) and minimize code repetition:

* add_parking.dart will be a form to post/create an available parking space 

* find_parking.dart will be a page to see available parking locations (list or map)

* menu_drawer.dart is the drawer that will show up when users click the menu icon in the upper left corner. Also created a widget to easily add new menu items.

* in style.dart, I added more Theme data and changed the styling on other pages so that they use elements of the Theme. Now it should be easier to make changes to the Theme and see that reflected on all pages (without having to go into each individual file and make the changes).