### PR TITLE
minor additions to parkingSpaces, creates initial tests, fixes layout

### DIFF
--- a/parkcore_app/lib/parking/add_parking.dart
+++ b/parkcore_app/lib/parking/add_parking.dart
@@ -867,10 +867,12 @@ class _MyAddParkingState extends State<AddParking> {
       'starttime': _startTime,
       'endtime': _endTime,
       'monthprice': _price,
-      'coordinates': _coordinates,
-      'coordinates_r': _coord_rand,
-      'downloadURL': _downloadURL,
-      'uid': getUserID(),
+      'coordinates': _coordinates, // generated from the input address
+      'coordinates_r': _coord_rand, // random coordinates near actual address
+      'downloadURL': _downloadURL, // for the image (put in firebase storage)
+      'uid': getUserID(), // parkingSpace owner is the current user
+      'reserved': [].toString(), // list of UIDs (if reserved, starts empty)
+      'cur_tenant': '', // current tenant (a UID, or empty if spot is available)
     };
 
     await Firestore.instance.runTransaction((transaction) async {

--- a/parkcore_app/lib/parking/add_parking.dart
+++ b/parkcore_app/lib/parking/add_parking.dart
@@ -206,25 +206,24 @@ class _MyAddParkingState extends State<AddParking> {
       ),
       drawer: MenuDrawer(),
       body: SingleChildScrollView(
-        child: ConstrainedBox(
-          constraints: BoxConstraints(),
-          child: Padding(
-            padding: const EdgeInsets.all(16.0),
-            child: Column(
-              children: <Widget>[
-                _incomplete || _invalidLoc
-                    ? Text(_errorMessage, style: TextStyle(color: Colors.red))
-                    : Text("Part " + _page.toString() + " of 5"),
-                SizedBox(height: 10),
-                Form(
-                  key: _formKey,
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: formPages(),
-                  ),
+        child: Padding(
+          padding: const EdgeInsets.all(16.0),
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            crossAxisAlignment: CrossAxisAlignment.center,
+            children: <Widget>[
+              _incomplete || _invalidLoc
+                ? Text(_errorMessage, style: TextStyle(color: Colors.red))
+                : Text("Part " + _page.toString() + " of 5"),
+              SizedBox(height: 10),
+              Form(
+                key: _formKey,
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: formPages(),
                 ),
-              ],
-            ),
+              ),
+            ],
           ),
         ),
       ),
@@ -773,15 +772,22 @@ class _MyAddParkingState extends State<AddParking> {
   List<Widget> pageButton(String buttonText) {
     return [
       Row(
-        mainAxisAlignment: MainAxisAlignment.spaceEvenly,
-        children: [
-          RaisedButton(
-            onPressed: validateAndSubmit,
-            child: Text(
-              buttonText,
-              style: Theme.of(context).textTheme.display3,
+        children: <Widget>[
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.center,
+              mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+              children: [
+                RaisedButton(
+                  onPressed: validateAndSubmit,
+                  child: Text(
+                    buttonText,
+                    style: Theme.of(context).textTheme.display3,
+                  ),
+                  color: Theme.of(context).accentColor,
+                ),
+              ],
             ),
-            color: Theme.of(context).accentColor,
           ),
         ],
       ),

--- a/parkcore_app/test/widget_test.dart
+++ b/parkcore_app/test/widget_test.dart
@@ -10,6 +10,9 @@ import 'package:flutter_test/flutter_test.dart';
 
 import 'package:parkcore_app/screens/home.dart';
 import 'package:parkcore_app/parking/add_parking.dart';
+import 'package:dropdown_formfield/dropdown_formfield.dart';
+//import 'package:geocoder/geocoder.dart';
+
 
 //void main() {
 //  testWidgets('MyHomePage has a title', (WidgetTester tester) async {
@@ -23,6 +26,7 @@ import 'package:parkcore_app/parking/add_parking.dart';
 //}
 
 void main() {
+
   testWidgets('My Home Page Widget', (WidgetTester tester) async {
     // Build our app and trigger a frame.
     await tester.pumpWidget(MaterialApp(
@@ -50,6 +54,7 @@ void main() {
     // Tap the search icon and trigger a frame
     await tester.tap(submit);
     await tester.pump();
+
     // Expect Text Widget message
     expect(find.text('Find parking near: Chico, CA'), findsOneWidget);
 
@@ -63,27 +68,36 @@ void main() {
 
     // Create the finders
     final titleFinder = find.text('Post Your Parking Space');
+    final Finder title = find.byKey(Key('title'));
+    final Finder address = find.byKey(Key('address'));
+    final Finder city = find.byKey(Key('city'));
+    final Finder zip = find.byKey(Key('zip'));
+
+    final Finder submit = find.widgetWithText(RaisedButton, 'Next: Parking Space Info');
+
     // Use the `findsNWidgets` matcher provided by flutter_test to
     // verify this Text widget appears exactly 2 times in the widget tree.
     expect(titleFinder, findsOneWidget);
-  });
+    expect(find.text("Part 1 of 5"), findsOneWidget);
 
-//  testWidgets('Counter increments smoke test', (WidgetTester tester) async {
-//    // Build our app and trigger a frame.
-//    await tester.pumpWidget(MaterialApp(
-//      home: MyHomePage(title: "ParkCore"),
-//    ));
-//
-//    // Verify that our counter starts at 0.
-//    expect(find.text('0'), findsOneWidget);
-//    expect(find.text('1'), findsNothing);
-//
-//    // Tap the '+' icon and trigger a frame.
-//    await tester.tap(find.byIcon(Icons.add));
-//    await tester.pump();
-//
-//    // Verify that our counter has incremented.
-//    expect(find.text('0'), findsNothing);
-//    expect(find.text('1'), findsOneWidget);
-//  });
+    // expect to find 1 form
+    expect(find.byType(Form),findsOneWidget);
+    // On 1st page of form, find 4 TextFormField Widgets, 1 DropDownFormField
+    // Widget, and 1 Raised Button
+    expect(find.byType(TextFormField),findsNWidgets(4));
+    expect(find.byType(DropDownFormField),findsOneWidget);
+    expect(find.byType(RaisedButton),findsOneWidget);
+
+    // Test text field form input
+    await tester.enterText(title, '');
+    await tester.enterText(address, '');
+    await tester.enterText(city, '');
+    await tester.enterText(zip, '');
+
+    // Tap the search icon and trigger a frame
+    await tester.tap(submit);
+    await tester.pump();
+    // Expect Text Widget message
+    //expect(find.text("We can't find you!\nPlease enter a valid location."), findsOneWidget);
+  });
 }

--- a/parkcore_app/test/widget_test.dart
+++ b/parkcore_app/test/widget_test.dart
@@ -9,6 +9,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:parkcore_app/screens/home.dart';
+import 'package:parkcore_app/parking/add_parking.dart';
 
 //void main() {
 //  testWidgets('MyHomePage has a title', (WidgetTester tester) async {
@@ -22,22 +23,67 @@ import 'package:parkcore_app/screens/home.dart';
 //}
 
 void main() {
-  testWidgets('Counter increments smoke test', (WidgetTester tester) async {
+  testWidgets('My Home Page Widget', (WidgetTester tester) async {
     // Build our app and trigger a frame.
     await tester.pumpWidget(MaterialApp(
-      home: MyHomePage(title: "title"),
+      home: MyHomePage(title: "ParkCore"),
     ));
 
-    // Verify that our counter starts at 0.
-    expect(find.text('0'), findsOneWidget);
-    expect(find.text('1'), findsNothing);
+    // Create the finders
+    final titleFinder = find.text('ParkCore');
+    final Finder searchinput = find.widgetWithText(TextFormField, 'Search by location');
+    final Finder submit = find.widgetWithIcon(IconButton, Icons.search);
 
-    // Tap the '+' icon and trigger a frame.
-    await tester.tap(find.byIcon(Icons.add));
+    // Use the `findsNWidgets` matcher provided by flutter_test to
+    // verify this Text widget appears exactly 2 times in the widget tree.
+    expect(titleFinder, findsNWidgets(2));
+
+    // Finds 1 TextFormField Widget (for search input field in 1 Form)
+    expect(find.byType(TextFormField),findsOneWidget);
+    expect(find.byType(Form),findsOneWidget);
+
+    // Finds 3 IconButton Widgets (search, ParkCore logo, and menu icons)
+    expect(find.byType(IconButton),findsNWidgets(3));
+
+    // Test form search field input
+    await tester.enterText(searchinput, 'Chico, CA');
+    // Tap the search icon and trigger a frame
+    await tester.tap(submit);
     await tester.pump();
+    // Expect Text Widget message
+    expect(find.text('Find parking near: Chico, CA'), findsOneWidget);
 
-    // Verify that our counter has incremented.
-    expect(find.text('0'), findsNothing);
-    expect(find.text('1'), findsOneWidget);
   });
+
+  testWidgets('My Add Parking Widget', (WidgetTester tester) async {
+    // Build our app and trigger a frame.
+    await tester.pumpWidget(MaterialApp(
+      home: AddParking(title: 'Post Your Parking Space'),
+    ));
+
+    // Create the finders
+    final titleFinder = find.text('Post Your Parking Space');
+    // Use the `findsNWidgets` matcher provided by flutter_test to
+    // verify this Text widget appears exactly 2 times in the widget tree.
+    expect(titleFinder, findsOneWidget);
+  });
+
+//  testWidgets('Counter increments smoke test', (WidgetTester tester) async {
+//    // Build our app and trigger a frame.
+//    await tester.pumpWidget(MaterialApp(
+//      home: MyHomePage(title: "ParkCore"),
+//    ));
+//
+//    // Verify that our counter starts at 0.
+//    expect(find.text('0'), findsOneWidget);
+//    expect(find.text('1'), findsNothing);
+//
+//    // Tap the '+' icon and trigger a frame.
+//    await tester.tap(find.byIcon(Icons.add));
+//    await tester.pump();
+//
+//    // Verify that our counter has incremented.
+//    expect(find.text('0'), findsNothing);
+//    expect(find.text('1'), findsOneWidget);
+//  });
 }


### PR DESCRIPTION
A few minor changes:
* adds "reserved" to parkingSpaces -- a list that will hold UIDs of people who are interested in reserving the spot (starts empty)
* adds "cur_tenant" to parkingSpaces -- a string that will hold the UID of the current tenant (person who is using the spot; if empty => spot is available)
* adds some simple Widget tests for the home page and the add_parking page
* fixes layout issue for button on add_parking page (found while testing)